### PR TITLE
fixed compile issue by disambiguating DeleteSome and RefineSome::prepare

### DIFF
--- a/core/include/HMP/Actions/DeleteSome.hpp
+++ b/core/include/HMP/Actions/DeleteSome.hpp
@@ -22,6 +22,7 @@ namespace HMP::Actions
 
 		const std::vector<std::pair<const Dag::NodeHandle<Dag::Delete>, Dag::Element* const>> m_operations;
 
+		std::vector<std::pair<const Dag::NodeHandle<Dag::Delete>, Dag::Element* const>> prepare(const std::vector<Dag::Element*>& _elements);
 		void apply() override;
 		void unapply() override;
 

--- a/core/include/HMP/Actions/RefineSome.hpp
+++ b/core/include/HMP/Actions/RefineSome.hpp
@@ -23,6 +23,7 @@ namespace HMP::Actions
 		const std::vector<std::pair<const Dag::NodeHandle<Dag::Refine>, Dag::Element* const>> m_operations;
 		Meshing::Mesher::State m_oldState;
 
+		std::vector<std::pair<const Dag::NodeHandle<Dag::Refine>, Dag::Element* const>> prepare(const std::vector<Dag::Element*>& _elements);
 		void apply() override;
 		void unapply() override;
 

--- a/core/src/Actions/DeleteSome.cpp
+++ b/core/src/Actions/DeleteSome.cpp
@@ -7,7 +7,7 @@
 namespace HMP::Actions
 {
 
-	std::vector<std::pair<const Dag::NodeHandle<Dag::Delete>, Dag::Element* const>> prepare(const std::vector<Dag::Element*>& _elements)
+	std::vector<std::pair<const Dag::NodeHandle<Dag::Delete>, Dag::Element* const>> DeleteSome::prepare(const std::vector<Dag::Element*>& _elements)
 	{
 		return cpputils::range::of(_elements)
 			.map([](Dag::Element* _el)

--- a/core/src/Actions/RefineSome.cpp
+++ b/core/src/Actions/RefineSome.cpp
@@ -8,7 +8,7 @@
 namespace HMP::Actions
 {
 
-	std::vector<std::pair<const Dag::NodeHandle<Dag::Refine>, Dag::Element* const>> prepare(const std::vector<Dag::Element*>& _elements)
+	std::vector<std::pair<const Dag::NodeHandle<Dag::Refine>, Dag::Element* const>> RefineSome::prepare(const std::vector<Dag::Element*>& _elements)
 	{
 		return cpputils::range::of(_elements)
 			.map([](Dag::Element* _el)


### PR DESCRIPTION
Hi,

I got the following error when building the project :
```shell
[100%] Linking CXX executable gui
/usr/bin/ld: ../core/libcore.a(RefineSome.cpp.o): in function `HMP::Actions::prepare(std::vector<HMP::Dag::Element*, std::allocator<HMP::Dag::Element*> > const&)':
RefineSome.cpp:(.text+0x13a): multiple definition of `HMP::Actions::prepare(std::vector<HMP::Dag::Element*, std::allocator<HMP::Dag::Element*> > const&)'; ../core/libcore.a(DeleteSome.cpp.o):DeleteSome.cpp:(.text+0x158): first defined here
collect2: error: ld returned 1 exit status
gmake[2]: *** [gui/CMakeFiles/gui.dir/build.make:478: gui/gui] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:11898: gui/CMakeFiles/gui.dir/all] Error 2
gmake: *** [Makefile:136: all] Error 2
```

I am not sure whether this is a good solution but declaring `prepare` in the `DeleteSome` and `RefineSome` headers seemed to fix it for me.